### PR TITLE
Fix #12: encryption keys shown 'not connected' when key usage lacks keyEncipherment bit

### DIFF
--- a/EpiSource.KeePass.Ekf/Crypto/Windows/WindowsKeyPair.cs
+++ b/EpiSource.KeePass.Ekf/Crypto/Windows/WindowsKeyPair.cs
@@ -125,16 +125,30 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
             }
         }
 
+        // Key usage flags asserting the certificate may be used for CMS encryption/decryption.
+        // Besides the standard RSA keyEncipherment and (EC)DH keyAgreement bits, some smartcards
+        // (e.g. PIV cards) mark their encryption certificate with dataEncipherment instead of
+        // keyEncipherment. Gate on any of these bits and let the key algorithm (pubKeyInfo) decide
+        // between key transfer and key agreement - requiring an exact bit per primitive locks out
+        // otherwise valid encryption keys (see issue #12). Absent a key usage extension all bits are
+        // assumed set (see UpdateKeyUsageFlags), so unrestricted certificates keep working.
+        private const X509KeyUsageFlags encryptionKeyUsage =
+            X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.DataEncipherment | X509KeyUsageFlags.KeyAgreement;
+
+        private bool KeyUsageAllowsEncryption {
+            get { return (this.keyUsageFlags & encryptionKeyUsage) != X509KeyUsageFlags.None; }
+        }
+
         public bool CanKeyAgree {
             get {
-                return (this.keyUsageFlags & X509KeyUsageFlags.KeyAgreement) == X509KeyUsageFlags.KeyAgreement
+                return this.KeyUsageAllowsEncryption
                         && this.pubKeyInfo.CanKeyAgree && (this.privKeyInfo == null || this.privKeyInfo.CanKeyAgree);
             }
         }
 
         public bool CanKeyTransfer {
             get {
-                return (this.keyUsageFlags & X509KeyUsageFlags.KeyEncipherment) == X509KeyUsageFlags.KeyEncipherment
+                return this.KeyUsageAllowsEncryption
                         && this.pubKeyInfo.CanKeyTransfer && (this.privKeyInfo == null || this.privKeyInfo.CanKeyTransfer);
             }
         }


### PR DESCRIPTION
Fixes #12.

### Problem
v1.3.4 (dc69662, "Exclude certificates with incompatible key usage flags") gated `CanKeyTransfer` on an **exact** `keyEncipherment` bit and `CanKeyAgree` on an exact `keyAgreement` bit.

Encryption smartcard certificates that mark their key with `dataEncipherment` (common on PIV/RSA cards) — or otherwise omit the exact bit — then fail `CanEncryptCms`/`CanDecryptCms`. `SmartcardKeyPairs.GetAllPivKeyPairs()` drops the live card key, so `DefaultKeyPairProvider.RefreshImpl` never replaces the stale, un-refreshed key deserialized from the EKF. The unlock dialog renders it as **"not connected"**, locking the user out of the database.

### Fix
Gate encryption capability on a single predicate — any of `keyEncipherment | dataEncipherment | keyAgreement` — and let the key algorithm (`pubKeyInfo`) decide key-transfer vs key-agreement, instead of requiring an exact bit per primitive.

Intent of the original change is preserved:
- Signing-only certificates (`keyUsage = digitalSignature`, no encryption bit) remain excluded.
- `CanSign` is unchanged (still requires `digitalSignature`).
- Certificates without a key-usage extension keep all bits via the existing `DefaultIfEmpty(~None)` and continue to work.

Only over-strict exact-bit matching is relaxed; no signing-only certificate is re-admitted.

### Testing
Reasoned/static change only — I don't have Windows + the affected smartcard to exercise the CAPI path. Review of the key-usage truth table welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)