### PR TITLE
Optionally filter key usage in frontend

### DIFF
--- a/EpiSource.KeePass.Ekf/Crypto/Windows/WindowsKeyPair.cs
+++ b/EpiSource.KeePass.Ekf/Crypto/Windows/WindowsKeyPair.cs
@@ -22,8 +22,6 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
 
         private KeyInfo pubKeyInfo;
         
-        private X509KeyUsageFlags keyUsageFlags;
-        
         public void GetObjectData(SerializationInfo info, StreamingContext context) {
             info.AddValue("cert", this.cert);
             info.AddValue("privKeyInfo", this.privKeyInfo);
@@ -48,21 +46,10 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
                 
                 this.cert = matchingCert ?? preliminaryCert;
             }
-            
-            this.UpdateKeyUsageFlags();
         }
         
         private WindowsKeyPair(X509Certificate2 cert) {
             this.cert = cert;
-            this.UpdateKeyUsageFlags();
-        }
-
-        private void UpdateKeyUsageFlags() {
-            this.keyUsageFlags = this.cert.Extensions
-                .OfType<X509KeyUsageExtension>()
-                .Select(usage => usage.KeyUsages)
-                .DefaultIfEmpty(~X509KeyUsageFlags.None)
-                .FirstOrDefault();
         }
 
         public static WindowsKeyPair FromX509Certificate(X509Certificate2 cert) {
@@ -127,22 +114,19 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
 
         public bool CanKeyAgree {
             get {
-                return (this.keyUsageFlags & X509KeyUsageFlags.KeyAgreement) == X509KeyUsageFlags.KeyAgreement
-                        && this.pubKeyInfo.CanKeyAgree && (this.privKeyInfo == null || this.privKeyInfo.CanKeyAgree);
+                return this.pubKeyInfo.CanKeyAgree && (this.privKeyInfo == null || this.privKeyInfo.CanKeyAgree);
             }
         }
 
         public bool CanKeyTransfer {
             get {
-                return (this.keyUsageFlags & X509KeyUsageFlags.KeyEncipherment) == X509KeyUsageFlags.KeyEncipherment
-                        && this.pubKeyInfo.CanKeyTransfer && (this.privKeyInfo == null || this.privKeyInfo.CanKeyTransfer);
+                return this.pubKeyInfo.CanKeyTransfer && (this.privKeyInfo == null || this.privKeyInfo.CanKeyTransfer);
             }
         }
 
         public bool CanSign {
             get {
-                return (this.keyUsageFlags & X509KeyUsageFlags.DigitalSignature) == X509KeyUsageFlags.DigitalSignature
-                        && this.pubKeyInfo.CanSign && (this.privKeyInfo == null || this.privKeyInfo.CanSign);
+                return this.pubKeyInfo.CanSign && (this.privKeyInfo == null || this.privKeyInfo.CanSign);
             }
         }
         
@@ -174,8 +158,6 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
             this.privKeyInfo = nextPrivKeyInfo;
             this.pubKeyInfo = nextPubKeyInfo;
             
-            this.UpdateKeyUsageFlags();
-
             return true;
         }
     }

--- a/EpiSource.KeePass.Ekf/Crypto/X509CertificateExtensions.cs
+++ b/EpiSource.KeePass.Ekf/Crypto/X509CertificateExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 
@@ -5,6 +6,24 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
     public static class X509CertificateExtensions {
         public static X509SubjectKeyIdentifierExtension GetSubjectKeyIdentifierExtension(this X509Certificate2 cert) {
             return cert.Extensions.OfType<X509SubjectKeyIdentifierExtension>().FirstOrDefault();
+        }
+        
+        public static X509KeyUsageFlags GetKeyUsageExtension(this X509Certificate2 cert) {
+            return cert.Extensions
+                       .OfType<X509KeyUsageExtension>()
+                       .Select(usage => usage.KeyUsages)
+                       .DefaultIfEmpty(~X509KeyUsageFlags.None)
+                       .FirstOrDefault();
+        }
+
+        public static bool AllowsKeyUsageAnyOf(this X509Certificate2 cert, params X509KeyUsageFlags[] anyWanted) {
+            var allowedFlags = cert.GetKeyUsageExtension();
+            return anyWanted.Any(flag => allowedFlags.HasFlag(flag));
+        }
+        
+        public static bool AllowsKeyUsageAllOf(this X509Certificate2 cert, params X509KeyUsageFlags[] allWanted) {
+            var allowedFlags = cert.GetKeyUsageExtension();
+            return allWanted.All(flag => allowedFlags.HasFlag(flag));
         }
     }
 }

--- a/EpiSource.KeePass.Ekf/Resources/Strings.Designer.cs
+++ b/EpiSource.KeePass.Ekf/Resources/Strings.Designer.cs
@@ -123,6 +123,15 @@ namespace Episource.KeePass.EKF.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Ignore key usage restrictions (show all).
+        /// </summary>
+        internal static string EditEncryptedKeyFileDialog_CheckBoxShowOtherUsage {
+            get {
+                return ResourceManager.GetString("EditEncryptedKeyFileDialog.CheckBoxShowOtherUsage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Algorithm.
         /// </summary>
         internal static string EditEncryptedKeyFileDialog_ColumnAlgorithm {

--- a/EpiSource.KeePass.Ekf/Resources/Strings.resx
+++ b/EpiSource.KeePass.Ekf/Resources/Strings.resx
@@ -96,6 +96,9 @@
   <data name="EditEncryptedKeyFileDialog.ButtonExport" xml:space="preserve">
     <value>Export</value>
   </data>
+  <data name="EditEncryptedKeyFileDialog.CheckBoxShowOtherUsage" xml:space="preserve">
+    <value>Ignore key usage restrictions (show all)</value>
+  </data>
   <data name="EditEncryptedKeyFileDialog.ButtonSelectActiveDbKeyFile" xml:space="preserve">
     <value>Select active key file</value>
   </data>

--- a/EpiSource.KeePass.Ekf/UI/EditEncryptedKeyFileDialog.controls.cs
+++ b/EpiSource.KeePass.Ekf/UI/EditEncryptedKeyFileDialog.controls.cs
@@ -2,11 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Windows.Forms;
 
+using EpiSource.KeePass.Ekf.Crypto.Windows;
 using EpiSource.KeePass.Ekf.Plugin;
 
 using Episource.KeePass.EKF.Resources;
+
+using EpiSource.KeePass.Ekf.Util;
 
 using KeePass.UI;
 
@@ -15,13 +19,19 @@ using ContentAlignment = System.Drawing.ContentAlignment;
 namespace EpiSource.KeePass.Ekf.UI {
     public sealed partial class EditEncryptedKeyFileDialogFactory {
         private partial class EditEncryptedKeyFileDialog : Form, IGwmWindow {
+            private const FontStyle actionFont = FontStyle.Bold;
+            
             private static readonly string noChangeCaption = Strings.EditEncryptedKeyFileDialog_KeyActionNoChange;
+            private static readonly string newKeyAction = Strings.EditEncryptedKeyFileDialog_KeyActionAuthorize;
+            private static readonly string delKeyAction = Strings.EditEncryptedKeyFileDialog_KeyActionUnauthorize;
+            
             private readonly TableLayoutPanel layout = new TableLayoutPanel();
             private readonly CustomListViewEx keyListView = new CustomListViewEx();
 
             private TextBox txtKeySource;
 
             private Label lblValidationError;
+            private CheckBox chkAnyKeyUsage;
             private Button btnOk;
 
             private readonly Dictionary<string, KeyPairModel> keyList = new Dictionary<string, KeyPairModel>();
@@ -43,10 +53,11 @@ namespace EpiSource.KeePass.Ekf.UI {
                 this.layout.AutoSize = true;
                 this.layout.AutoSizeMode = AutoSizeMode.GrowAndShrink;
                 this.layout.Dock = DockStyle.Fill;
-                this.layout.ColumnCount = 4;
+                this.layout.ColumnCount = 5;
                 this.layout.RowCount = 6;
                 this.layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
                 this.layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, width: 100.0f));
+                this.layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
                 this.layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
                 this.layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
                 this.layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
@@ -83,7 +94,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                     TabStop = false
                 };
                 this.layout.Controls.Add(txtDb, column: 1, row: 0);
-                this.layout.SetColumnSpan(txtDb, value: 3);
+                this.layout.SetColumnSpan(txtDb, value: 4);
 
                 var lblKeySource = new Label {
                     Text = Strings.EditEncryptedKeyFileDialog_LabelKeySource,
@@ -101,7 +112,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                 };
 
                 this.layout.Controls.Add(this.txtKeySource, column: 1, row: 1);
-                this.layout.SetColumnSpan(this.txtKeySource, value: 2);
+                this.layout.SetColumnSpan(this.txtKeySource, value: 3);
 
                 // TODO: SplitButtonEx currently supports windows only! DropDown not shown on other platforms.
                 var btnExport = new SplitButtonEx {
@@ -130,7 +141,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                 btnImportKey.Click += (sender, args) => this.ImportKey();
                 btnExport.SplitDropDownMenu.Items.Add(btnImportKey);
 
-                this.layout.Controls.Add(btnExport, 3, 1);
+                this.layout.Controls.Add(btnExport, 4, 1);
             }
 
             // ReSharper disable once UnusedMember.Local
@@ -149,10 +160,22 @@ namespace EpiSource.KeePass.Ekf.UI {
                 this.lblValidationError = new Label {
                     AutoSize = true,
                     ForeColor = SystemColors.GrayText,
-                    TabStop = false
+                    TabStop = false,
+                    Anchor = AnchorStyles.Left
                 };
                 this.layout.Controls.Add(this.lblValidationError, column: 0, row: 5);
                 this.layout.SetColumnSpan(this.lblValidationError, value: 2);
+
+                this.chkAnyKeyUsage = new CheckBox {
+                    Text = Strings.EditEncryptedKeyFileDialog_CheckBoxShowOtherUsage,
+                    AutoSize = true,
+                    Anchor = AnchorStyles.Left,
+                    TextAlign = ContentAlignment.MiddleLeft
+                };
+                this.chkAnyKeyUsage.CheckedChanged += (sender, args) => {
+                    this.RefreshKeyListView();
+                };
+                this.layout.Controls.Add(this.chkAnyKeyUsage, column: 2, row: 5);
 
                 this.btnOk = new Button {
                     Text = Strings.AnyUI_ButtonOK,
@@ -161,7 +184,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                     Width = UIConstants.DefaultButtonWidth,
                     TabIndex = 0
                 };
-                this.layout.Controls.Add(this.btnOk, column: 2, row: 5);
+                this.layout.Controls.Add(this.btnOk, column: 3, row: 5);
                 this.AcceptButton = this.btnOk;
 
                 var btnCancel = new Button {
@@ -171,15 +194,11 @@ namespace EpiSource.KeePass.Ekf.UI {
                     Width = UIConstants.DefaultButtonWidth,
                     TabIndex = 1
                 };
-                this.layout.Controls.Add(btnCancel, column: 3, row: 5);
+                this.layout.Controls.Add(btnCancel, column: 4, row: 5);
                 this.CancelButton = btnCancel;
             }
 
             private void InitializeKeyList() {
-                const FontStyle actionFont = FontStyle.Bold;
-                var newKeyAction = Strings.EditEncryptedKeyFileDialog_KeyActionAuthorize;
-                var delKeyAction = Strings.EditEncryptedKeyFileDialog_KeyActionUnauthorize;
-
                 this.keyListView.Dock = DockStyle.Fill;
                 this.keyListView.AutoSize = true;
                 this.keyListView.FullRowSelect = true;
@@ -235,18 +254,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                     model.NextAuthorization = args.NewValue == CheckState.Checked ?
                         KeyPairModel.Authorization.Authorized : KeyPairModel.Authorization.Rejected;
 
-                    if (model.CurrentAuthorization != model.NextAuthorization) {
-                        item.Font = new Font(item.Font, actionFont);
-
-                        if (model.NextAuthorization == KeyPairModel.Authorization.Authorized) {
-                            item.Text = newKeyAction;
-                        } else {
-                            item.Text = delKeyAction;
-                        }
-                    } else {
-                        item.Font = null;
-                        item.Text = noChangeCaption;
-                    }
+                    this.UpdateItemAction(item);
 
                     this.OnContentChanged();
                 };
@@ -274,6 +282,10 @@ namespace EpiSource.KeePass.Ekf.UI {
 
                 // make sure the last columns spans all the remaining width
                 this.Resize += (sender, args) => {
+                    if (this.keyListView.Columns.Count == 0) {
+                        return;
+                    }
+                    
                     // -2: auto size using header and content & last column stretches
                     this.keyListView.Columns[this.keyListView.Columns.Count - 1].Width = -2;
                 };
@@ -307,30 +319,75 @@ namespace EpiSource.KeePass.Ekf.UI {
                 this.lblValidationError.Text = message;
             }
 
+            private void ClearKeyList() {
+                this.keyList.Clear();
+            }
+            
             private bool AddKeyIfNew(KeyPairModel keyModel) {
                 var cert = keyModel.KeyPair.Certificate;
                 if (this.keyList.ContainsKey(cert.Thumbprint)) {
                     return false;
                 }
-
-                var item = new ListViewItem(noChangeCaption);
-                item.UseItemStyleForSubItems = false;
-                item.Tag = keyModel;
-                item.Checked = keyModel.NextAuthorization == KeyPairModel.Authorization.Authorized;
-                item.SubItems.Add(cert.Subject);
-                item.SubItems.Add(cert.SerialNumber);
-                item.SubItems.Add(cert.PublicKey.Oid.FriendlyName);
-                item.SubItems.Add(keyModel.ProviderName);
-                item.ToolTipText = string.Format(Strings.Culture, Strings.EditEncryptedKeyFileDialog_LabelThumbprint, cert.Thumbprint);
-
+                
                 this.keyList.Add(cert.Thumbprint, keyModel);
-                this.keyListView.Items.Add(item);
+                return true;
+            }
 
+            private void RefreshKeyListView() {
+                this.keyListView.BeginUpdate();
+                
+                this.keyListView.Items.Clear();
+
+                this.keyList.Values
+                    .OrderBy(m => String.IsNullOrWhiteSpace(m.KeyPair.Certificate.Subject))
+                    .ThenBy(m => m.KeyPair.Certificate.Subject)
+                    .ThenBy(m => m.KeyPair.Certificate.SerialNumber)
+                    .ForEach(m => {
+                        if (!this.chkAnyKeyUsage.Checked 
+                                && m.NextAuthorization != KeyPairModel.Authorization.Authorized
+                                && m.NextAuthorization == m.CurrentAuthorization
+                                && !m.KeyPair.Certificate.AllowsKeyUsageAnyOf(
+                                    X509KeyUsageFlags.DataEncipherment, X509KeyUsageFlags.KeyAgreement, X509KeyUsageFlags.KeyEncipherment)) {
+                            return;
+                        }
+                        
+                        var item = new ListViewItem(noChangeCaption);
+                        item.UseItemStyleForSubItems = false;
+                        item.Tag = m;
+                        item.Checked = m.NextAuthorization == KeyPairModel.Authorization.Authorized;
+                        
+                        this.UpdateItemAction(item);
+                        
+                        var cert = m.KeyPair.Certificate;
+                        item.SubItems.Add(cert.Subject);
+                        item.SubItems.Add(cert.SerialNumber);
+                        item.SubItems.Add(cert.PublicKey.Oid.FriendlyName);
+                        item.SubItems.Add(m.ProviderName);
+                        item.ToolTipText = string.Format(Strings.Culture, Strings.EditEncryptedKeyFileDialog_LabelThumbprint, cert.Thumbprint);
+                
+                        this.keyListView.Items.Add(item);
+                    });
+                
                 // autosize
+                this.keyListView.EndUpdate();
                 this.keyListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
                 this.keyListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+            }
 
-                return true;
+            private void UpdateItemAction(ListViewItem item) {
+                var model = (KeyPairModel) item.Tag;
+                if (model.CurrentAuthorization != model.NextAuthorization) {
+                    item.Font = new Font(item.Font, actionFont);
+
+                    if (model.NextAuthorization == KeyPairModel.Authorization.Authorized) {
+                        item.Text = newKeyAction;
+                    } else {
+                        item.Text = delKeyAction;
+                    }
+                } else {
+                    item.Font = null;
+                    item.Text = noChangeCaption;
+                }
             }
 
             protected override void OnShown(EventArgs e) {

--- a/EpiSource.KeePass.Ekf/UI/EditEncryptedKeyFileDialog.cs
+++ b/EpiSource.KeePass.Ekf/UI/EditEncryptedKeyFileDialog.cs
@@ -42,8 +42,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                 this.permitNewKey = permitNewKey;
 
                 this.InitializeUI();
-
-                // AddKeyIfNew requires UI to be initialized!
+                
                 foreach (var keyPair in authCandidates.GetAvailableKeyPairs()) {
                     if (!this.AddKeyIfNew(keyPair)) {
                         throw new ArgumentException(
@@ -51,6 +50,9 @@ namespace EpiSource.KeePass.Ekf.UI {
                             "authCandidates");
                     }
                 }
+                
+                // RefreshKeyList requires UI to be initialized!
+                this.RefreshKeyListView();
 
                 this.ValidateInput();
             }

--- a/EpiSource.KeePass.Ekf/Util/EnumerableExtensions.cs
+++ b/EpiSource.KeePass.Ekf/Util/EnumerableExtensions.cs
@@ -26,6 +26,13 @@ namespace EpiSource.KeePass.Ekf.Util {
                 }
             }
         }
+        
+        public static IEnumerable<T> ForEach<T>(this IEnumerable<T> enumerable, Action<T> action) {
+            foreach (T item in enumerable) {
+                action(item);
+            }
+            return enumerable;
+        }
 
         private class StructuralEqualityComparer<T> : IEqualityComparer<T> where T : IStructuralEquatable {
 


### PR DESCRIPTION
alternative solution to #13 using optional frontend filtering when editing the  encrypted key file.  Filtering can be bypassed if needed by ticking the newly added checkbox "Ignore key usage restrictions (show all)". Key usage extension is ignored when selecting smart cards / certificates to decrypt the key file. Therefore any permitted cert / card can be used to decrypt the key file, independent of the key usage extension.

Should solve #12. @TickoSpy: please confirm.