### PR TITLE
Show private key state & allow healing

### DIFF
--- a/EpiSource.KeePass.Ekf/Crypto/IKeyPair.cs
+++ b/EpiSource.KeePass.Ekf/Crypto/IKeyPair.cs
@@ -23,6 +23,13 @@ namespace EpiSource.KeePass.Ekf.Crypto {
         bool IsAccessible { get; }
         
         /// <summary>
+        /// Retrieves whether the key container reports a mismatch between the certificate and the private key.
+        /// This happens e.g. if the key slot of the smart card has been overwritten and no longer matches the
+        /// cached certificate. 
+        /// </summary>
+        bool? IsMismatch { get; }
+        
+        /// <summary>
         /// Retrieves whether the decrypt CMS operation is likely to succeed now. Some hardware devices might require
         /// confirmation for this operation to succeed.
         /// </summary>

--- a/EpiSource.KeePass.Ekf/Crypto/KeyInfo.cs
+++ b/EpiSource.KeePass.Ekf/Crypto/KeyInfo.cs
@@ -10,19 +10,21 @@ namespace EpiSource.KeePass.Ekf.Crypto {
         private readonly bool canSign;
         private readonly bool canExport;
         private readonly bool isAccessible;
+        private readonly bool isKeyMismatch;
         private readonly bool? isHardware;
         private readonly bool? isRemovable;
 
-        public KeyInfo() : this(false, false, false, false, false, null, null) {
+        public KeyInfo() : this(false, false, false, false, false, false, null, null) {
             
         }
 
-        public KeyInfo(bool canKeyAgree, bool canKeyTransfer, bool canSign, bool canExport, bool isAccessible, bool? isHardware, bool? isRemovable) {
+        public KeyInfo(bool canKeyAgree, bool canKeyTransfer, bool canSign, bool canExport, bool isAccessible, bool isKeyMismatch, bool? isHardware, bool? isRemovable) {
             this.canKeyTransfer = canKeyTransfer;
             this.canKeyAgree = canKeyAgree;
             this.canSign = canSign;
             this.canExport = canExport;
             this.isAccessible = isAccessible;
+            this.isKeyMismatch = isKeyMismatch;
             this.isHardware = isHardware;
             this.isRemovable = isRemovable;
         }
@@ -57,6 +59,12 @@ namespace EpiSource.KeePass.Ekf.Crypto {
             }
         }
 
+        public bool IsKeyMismatch {
+            get {
+                return this.isKeyMismatch;
+            }
+        }
+
         public bool? IsHardware {
             get {
                 return this.isHardware;
@@ -70,7 +78,7 @@ namespace EpiSource.KeePass.Ekf.Crypto {
         }
         
         private bool Equals(KeyInfo other) {
-            return this.canKeyAgree == other.canKeyAgree && this.canKeyTransfer == other.canKeyTransfer && this.canExport == other.canExport && this.canSign == other.canSign && this.isAccessible == other.isAccessible && this.isHardware == other.isHardware && this.isRemovable == other.isRemovable;
+            return this.canKeyAgree == other.canKeyAgree && this.canKeyTransfer == other.canKeyTransfer && this.canExport == other.canExport && this.canSign == other.canSign && this.isAccessible == other.isAccessible && this.isKeyMismatch == other.isKeyMismatch && this.isHardware == other.isHardware && this.isRemovable == other.isRemovable;
         }
         public override bool Equals(object obj) {
             if (ReferenceEquals(null, obj)) return false;
@@ -84,6 +92,7 @@ namespace EpiSource.KeePass.Ekf.Crypto {
                 hashCode = (hashCode * 397) ^ this.canExport.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.canSign.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.isAccessible.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.isKeyMismatch.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.isHardware.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.isRemovable.GetHashCode();
                 return hashCode;

--- a/EpiSource.KeePass.Ekf/Crypto/Windows/NativeCapi.cs
+++ b/EpiSource.KeePass.Ekf/Crypto/Windows/NativeCapi.cs
@@ -400,7 +400,8 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
             if (!NativeCertPinvoke.CryptAcquireCertificatePrivateKey(cert.Handle,
                     CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_COMPARE_KEY_FLAG
                     | CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_USE_PROV_INFO_FLAG
-                    | CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_NO_HEALING
+                    // allowing healing sometimes resolves NTE_BAD_PUBLIC_KEY; the actual decryption doesn't use this either
+                    //| CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_NO_HEALING
                     | CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG
                     | CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_SILENT_FLAG,
                     ref optOwner, out keyHandleRaw, out keySpec, out mustFreeHandle)) {
@@ -417,7 +418,8 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
                     // retry without CRYPT_ACQUIRE_COMPARE_KEY_FLAG
                     acquireFailed = !NativeCertPinvoke.CryptAcquireCertificatePrivateKey(cert.Handle,
                         CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_USE_PROV_INFO_FLAG
-                        | CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_NO_HEALING
+                        // allowing healing sometimes resolves NTE_BAD_PUBLIC_KEY; the actual decryption doesn't use this either
+                        //| CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_NO_HEALING
                         | CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG
                         | CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_SILENT_FLAG,
                         ref optOwner, out keyHandleRaw, out keySpec, out mustFreeHandle);

--- a/EpiSource.KeePass.Ekf/Crypto/Windows/NativeCapi.cs
+++ b/EpiSource.KeePass.Ekf/Crypto/Windows/NativeCapi.cs
@@ -432,10 +432,7 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
                         Enum.GetName(typeof(CryptoResult), errorCode) ?? "N/A", errorCode);
                     
                     return new KeyInfo(canKeyAgree, canKeyTransfer, canSign, canExport, false,
-                            isPubKeyMismatch 
-                                || errorCode == CryptoResult.NTE_BAD_KEYSET
-                                || errorCode == CryptoResult.NTE_BAD_KEY
-                                || errorCode == CryptoResult.NTE_BAD_ALGID,
+                            isPubKeyMismatch || errorCode == CryptoResult.NTE_BAD_KEY,
                             isHardware, isRemovable);
                 }
             }

--- a/EpiSource.KeePass.Ekf/Crypto/Windows/NativeCapi.cs
+++ b/EpiSource.KeePass.Ekf/Crypto/Windows/NativeCapi.cs
@@ -347,7 +347,7 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
             }
         }
         
-        public static KeyInfo QueryCertificatePrivateKey(X509Certificate2 cert) {
+        public static KeyInfo QueryCertificatePrivateKey(X509Certificate2 cert, bool comparePublicKey = true) {
             // see also:
             //  - https://learn.microsoft.com/en-us/windows/win32/seccng/key-storage-property-identifiers
             //  - https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptgetprovparam
@@ -363,6 +363,7 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
             bool? isRemovable = null;
             bool canExport = false;
             bool canKeyAgree = pubKeyInfo.CanKeyAgree;
+            bool isPubKeyMismatch = false;
             
             // 0: Ncrypt Key Provider (no indication) - let's assume CanDecrypt until we've got more information
             // 1: We can decrypt, the key is of type Exchange
@@ -403,16 +404,45 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
                     | CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG
                     | CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_SILENT_FLAG,
                     ref optOwner, out keyHandleRaw, out keySpec, out mustFreeHandle)) {
+                var acquireFailed = true;
                 var errorCode = unchecked((CryptoResult)Marshal.GetLastWin32Error());
-                Console.WriteLine("[QueryCertificatePrivateKey] Failed to get private key info for certificate '{0}' ({1}): {2} (0x{3:X})",
-                    cert.Subject, String.IsNullOrEmpty(cert.FriendlyName) ? "N/A" : cert.FriendlyName,
-                    Enum.GetName(typeof(CryptoResult), errorCode) ?? "N/A", errorCode);
-                return new KeyInfo(canKeyAgree, canKeyTransfer, canSign, canExport, false, isHardware, isRemovable);
+                
+                if (errorCode == CryptoResult.NTE_BAD_PUBLIC_KEY) {
+                    isPubKeyMismatch = true;
+                    
+                    Console.WriteLine("[QueryCertificatePrivateKey] Failed to validate key association for certificate '{0}' ({1}): {2} (0x{3:X})",
+                        cert.Subject, String.IsNullOrEmpty(cert.FriendlyName) ? "N/A" : cert.FriendlyName,
+                        CryptoResult.NTE_BAD_PUBLIC_KEY, errorCode);
+                    
+                    // retry without CRYPT_ACQUIRE_COMPARE_KEY_FLAG
+                    acquireFailed = !NativeCertPinvoke.CryptAcquireCertificatePrivateKey(cert.Handle,
+                        CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_USE_PROV_INFO_FLAG
+                        | CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_NO_HEALING
+                        | CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG
+                        | CryptAcquireCertificatePrivateKeyFlags.CRYPT_ACQUIRE_SILENT_FLAG,
+                        ref optOwner, out keyHandleRaw, out keySpec, out mustFreeHandle);
+                    if (acquireFailed) {
+                        errorCode = unchecked((CryptoResult)Marshal.GetLastWin32Error());
+                    }
+                }
+
+                if (acquireFailed) {
+                    Console.WriteLine("[QueryCertificatePrivateKey] Failed to get private key info for certificate '{0}' ({1}): {2} (0x{3:X})",
+                        cert.Subject, String.IsNullOrEmpty(cert.FriendlyName) ? "N/A" : cert.FriendlyName,
+                        Enum.GetName(typeof(CryptoResult), errorCode) ?? "N/A", errorCode);
+                    
+                    return new KeyInfo(canKeyAgree, canKeyTransfer, canSign, canExport, false,
+                            isPubKeyMismatch 
+                                || errorCode == CryptoResult.NTE_BAD_KEYSET
+                                || errorCode == CryptoResult.NTE_BAD_KEY
+                                || errorCode == CryptoResult.NTE_BAD_ALGID,
+                            isHardware, isRemovable);
+                }
             }
 
             using (NcryptOrContextHandle keyHandle = NcryptOrContextHandle.of(keyHandleRaw, mustFreeHandle, keySpec)) {
                 if (keyHandle.IsInvalid) {
-                    return new KeyInfo(canKeyAgree, canKeyTransfer, canSign, canExport, false, isHardware, isRemovable);
+                    return new KeyInfo(canKeyAgree, canKeyTransfer, canSign, canExport, false, isPubKeyMismatch, isHardware, isRemovable);
                 }
                 
                 byte[] keyImplementation = GetNcryptOrCspProperty(keyHandle, "Impl Type", CryptGetProvParamType.PP_IMPTYPE, true);
@@ -434,13 +464,13 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
                 }
             }
             
-            return new KeyInfo(canKeyAgree, canKeyTransfer, canSign, canExport, true, isHardware, isRemovable);
+            return new KeyInfo(canKeyAgree, canKeyTransfer, canSign, canExport, true, isPubKeyMismatch, isHardware, isRemovable);
         }
 
         public static KeyInfo QueryCertificatePublicKey(X509Certificate2 cert) {
             return new KeyInfo(
                 IsKeyAgreeSupported(cert), IsEncryptionSupported(cert), false /*tbd*/,
-                true, true, false, false);
+                true, true, false, false, false);
         }
 
         private static PortableProtectedBinary DecryptEnvelopedCmsImpl(CryptMsgHandle cryptMsgHandle, CryptMsgRecipient recipient, bool alwaysSilent, string optContextDescription, IntPtr optOwner, PortableProtectedString optPin

--- a/EpiSource.KeePass.Ekf/Crypto/Windows/WindowsKeyPair.cs
+++ b/EpiSource.KeePass.Ekf/Crypto/Windows/WindowsKeyPair.cs
@@ -75,7 +75,11 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
         public bool IsAccessible {
             get { return this.privKeyInfo != null && this.privKeyInfo.IsAccessible && this.pubKeyInfo != null && this.pubKeyInfo.IsAccessible; }
         }
-        
+
+        public bool? IsMismatch {
+            get { return this.privKeyInfo == null ? (bool?) null : this.privKeyInfo.IsKeyMismatch; }
+        }
+
         public bool? CanExportPrivateKey {
             get {
                 var info = this.privKeyInfo;
@@ -131,7 +135,7 @@ namespace EpiSource.KeePass.Ekf.Crypto.Windows {
         }
         
         public bool IsReadyForDecryptCms {
-            get { return this.CanDecryptCms && this.IsAccessible; }
+            get { return this.CanDecryptCms && this.IsAccessible && this.IsMismatch != true; }
         }
         
         public bool IsReadyForEncryptCms {

--- a/EpiSource.KeePass.Ekf/EpiSource.KeePass.Ekf.csproj
+++ b/EpiSource.KeePass.Ekf/EpiSource.KeePass.Ekf.csproj
@@ -160,6 +160,7 @@
     <Compile Include="UI\SmartcardRequiredDialogFactory.cs" />
     <Compile Include="UI\UIConstants.cs" />
     <Compile Include="UI\UIFactory.cs" />
+    <Compile Include="UI\Util\KeyPairExtensions.cs" />
     <Compile Include="UI\Util\KeyPairProviderDeviceEventUpdater.cs" />
     <Compile Include="UI\Util\ListViewExtensions.cs" />
     <Compile Include="UI\Util\TimerExtensions.cs" />

--- a/EpiSource.KeePass.Ekf/EpiSource.KeePass.Ekf.csproj
+++ b/EpiSource.KeePass.Ekf/EpiSource.KeePass.Ekf.csproj
@@ -161,6 +161,7 @@
     <Compile Include="UI\UIConstants.cs" />
     <Compile Include="UI\UIFactory.cs" />
     <Compile Include="UI\Util\KeyPairProviderDeviceEventUpdater.cs" />
+    <Compile Include="UI\Util\ListViewExtensions.cs" />
     <Compile Include="UI\Util\TimerExtensions.cs" />
     <Compile Include="UI\Windows\InvalidWindowHandleException.cs" />
     <Compile Include="UI\Windows\NativeForms.pinvoke.cs">

--- a/EpiSource.KeePass.Ekf/EpiSource.KeePass.Ekf.csproj
+++ b/EpiSource.KeePass.Ekf/EpiSource.KeePass.Ekf.csproj
@@ -160,6 +160,8 @@
     <Compile Include="UI\SmartcardRequiredDialogFactory.cs" />
     <Compile Include="UI\UIConstants.cs" />
     <Compile Include="UI\UIFactory.cs" />
+    <Compile Include="UI\Util\KeyPairProviderDeviceEventUpdater.cs" />
+    <Compile Include="UI\Util\TimerExtensions.cs" />
     <Compile Include="UI\Windows\InvalidWindowHandleException.cs" />
     <Compile Include="UI\Windows\NativeForms.pinvoke.cs">
       <DependentUpon>NativeForms.cs</DependentUpon>

--- a/EpiSource.KeePass.Ekf/Resources/Strings.Designer.cs
+++ b/EpiSource.KeePass.Ekf/Resources/Strings.Designer.cs
@@ -168,6 +168,15 @@ namespace Episource.KeePass.EKF.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Private Key.
+        /// </summary>
+        internal static string EditEncryptedKeyFileDialog_ColumnState {
+            get {
+                return ResourceManager.GetString("EditEncryptedKeyFileDialog.ColumnState", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Subject.
         /// </summary>
         internal static string EditEncryptedKeyFileDialog_ColumnSubject {
@@ -308,6 +317,24 @@ namespace Episource.KeePass.EKF.Resources {
         internal static string EditEncryptedKeyFileDialog_KeySourceUnknown {
             get {
                 return ResourceManager.GetString("EditEncryptedKeyFileDialog.KeySourceUnknown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to connected.
+        /// </summary>
+        internal static string EditEncryptedKeyFileDialog_KeyStateConnected {
+            get {
+                return ResourceManager.GetString("EditEncryptedKeyFileDialog.KeyStateConnected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to not connected.
+        /// </summary>
+        internal static string EditEncryptedKeyFileDialog_KeyStateNotConnected {
+            get {
+                return ResourceManager.GetString("EditEncryptedKeyFileDialog.KeyStateNotConnected", resourceCulture);
             }
         }
         

--- a/EpiSource.KeePass.Ekf/Resources/Strings.Designer.cs
+++ b/EpiSource.KeePass.Ekf/Resources/Strings.Designer.cs
@@ -321,24 +321,6 @@ namespace Episource.KeePass.EKF.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to connected.
-        /// </summary>
-        internal static string EditEncryptedKeyFileDialog_KeyStateConnected {
-            get {
-                return ResourceManager.GetString("EditEncryptedKeyFileDialog.KeyStateConnected", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to not connected.
-        /// </summary>
-        internal static string EditEncryptedKeyFileDialog_KeyStateNotConnected {
-            get {
-                return ResourceManager.GetString("EditEncryptedKeyFileDialog.KeyStateNotConnected", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Database:.
         /// </summary>
         internal static string EditEncryptedKeyFileDialog_LabelDatabase {
@@ -389,6 +371,33 @@ namespace Episource.KeePass.EKF.Resources {
         internal static string EditEncryptedKeyFileDialog_ValidationMessageSelectSmartcard {
             get {
                 return ResourceManager.GetString("EditEncryptedKeyFileDialog.ValidationMessageSelectSmartcard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to connected.
+        /// </summary>
+        internal static string KeyPairExtension_KeyStateConnected {
+            get {
+                return ResourceManager.GetString("KeyPairExtension.KeyStateConnected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to mismatch.
+        /// </summary>
+        internal static string KeyPairExtension_KeyStateMismatch {
+            get {
+                return ResourceManager.GetString("KeyPairExtension.KeyStateMismatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to not connected.
+        /// </summary>
+        internal static string KeyPairExtension_KeyStateNotConnected {
+            get {
+                return ResourceManager.GetString("KeyPairExtension.KeyStateNotConnected", resourceCulture);
             }
         }
         
@@ -616,24 +625,6 @@ namespace Episource.KeePass.EKF.Resources {
         internal static string SmartcardRequiredDialog_DialogTitle {
             get {
                 return ResourceManager.GetString("SmartcardRequiredDialog.DialogTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to connected.
-        /// </summary>
-        internal static string SmartcardRequiredDialog_KeyStateConnected {
-            get {
-                return ResourceManager.GetString("SmartcardRequiredDialog.KeyStateConnected", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to not connected.
-        /// </summary>
-        internal static string SmartcardRequiredDialog_KeyStateNotConnected {
-            get {
-                return ResourceManager.GetString("SmartcardRequiredDialog.KeyStateNotConnected", resourceCulture);
             }
         }
         

--- a/EpiSource.KeePass.Ekf/Resources/Strings.resx
+++ b/EpiSource.KeePass.Ekf/Resources/Strings.resx
@@ -117,6 +117,9 @@
   <data name="EditEncryptedKeyFileDialog.ColumnChange" xml:space="preserve">
     <value>☑ Change</value>
   </data>
+  <data name="EditEncryptedKeyFileDialog.ColumnState" xml:space="preserve">
+    <value>Private Key</value>
+  </data>
   <data name="EditEncryptedKeyFileDialog.ColumnSubject" xml:space="preserve">
     <value>Subject</value>
   </data>
@@ -132,6 +135,12 @@
   <data name="EditEncryptedKeyFileDialog.LabelThumbprint" xml:space="preserve">
     <value>Thumbprint: {0}</value>
     <comment>{0} is thumbprint</comment>
+  </data>
+  <data name="EditEncryptedKeyFileDialog.KeyStateConnected" xml:space="preserve">
+    <value>connected</value>
+  </data>
+  <data name="EditEncryptedKeyFileDialog.KeyStateNotConnected" xml:space="preserve">
+    <value>not connected</value>
   </data>
   <data name="SmartcardOperationDialog.DialogTitle" xml:space="preserve">
     <value>Waiting for smartcard...</value>

--- a/EpiSource.KeePass.Ekf/Resources/Strings.resx
+++ b/EpiSource.KeePass.Ekf/Resources/Strings.resx
@@ -136,10 +136,13 @@
     <value>Thumbprint: {0}</value>
     <comment>{0} is thumbprint</comment>
   </data>
-  <data name="EditEncryptedKeyFileDialog.KeyStateConnected" xml:space="preserve">
+  <data name="KeyPairExtension.KeyStateConnected" xml:space="preserve">
     <value>connected</value>
   </data>
-  <data name="EditEncryptedKeyFileDialog.KeyStateNotConnected" xml:space="preserve">
+  <data name="KeyPairExtension.KeyStateMismatch" xml:space="preserve">
+    <value>mismatch</value>
+  </data>
+  <data name="KeyPairExtension.KeyStateNotConnected" xml:space="preserve">
     <value>not connected</value>
   </data>
   <data name="SmartcardOperationDialog.DialogTitle" xml:space="preserve">
@@ -153,12 +156,6 @@
   </data>
   <data name="SmartcardRequiredDialog.DialogTitle" xml:space="preserve">
     <value>Smartcard required</value>
-  </data>
-  <data name="SmartcardRequiredDialog.KeyStateConnected" xml:space="preserve">
-    <value>connected</value>
-  </data>
-  <data name="SmartcardRequiredDialog.KeyStateNotConnected" xml:space="preserve">
-    <value>not connected</value>
   </data>
   <data name="SmartcardRequiredDialog.DialogText" xml:space="preserve">
     <value>Please insert and select a smartcard from the list below.</value>

--- a/EpiSource.KeePass.Ekf/UI/EditEncryptedKeyFileDialog.controls.cs
+++ b/EpiSource.KeePass.Ekf/UI/EditEncryptedKeyFileDialog.controls.cs
@@ -10,6 +10,7 @@ using EpiSource.KeePass.Ekf.Plugin;
 
 using Episource.KeePass.EKF.Resources;
 
+using EpiSource.KeePass.Ekf.UI.Util;
 using EpiSource.KeePass.Ekf.Util;
 
 using KeePass.UI;
@@ -24,6 +25,8 @@ namespace EpiSource.KeePass.Ekf.UI {
             private static readonly string noChangeCaption = Strings.EditEncryptedKeyFileDialog_KeyActionNoChange;
             private static readonly string newKeyAction = Strings.EditEncryptedKeyFileDialog_KeyActionAuthorize;
             private static readonly string delKeyAction = Strings.EditEncryptedKeyFileDialog_KeyActionUnauthorize;
+            private static readonly string stateConnected = Strings.EditEncryptedKeyFileDialog_KeyStateConnected;
+            private static readonly string stateNotConnected = Strings.EditEncryptedKeyFileDialog_KeyStateNotConnected;
             
             private readonly TableLayoutPanel layout = new TableLayoutPanel();
             private readonly CustomListViewEx keyListView = new CustomListViewEx();
@@ -33,8 +36,6 @@ namespace EpiSource.KeePass.Ekf.UI {
             private Label lblValidationError;
             private CheckBox chkAnyKeyUsage;
             private Button btnOk;
-
-            private readonly Dictionary<string, KeyPairModel> keyList = new Dictionary<string, KeyPairModel>();
 
             // ReSharper disable once InconsistentNaming
             private void InitializeUI() {
@@ -211,6 +212,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                 // width "-2" -> auto size respecting header width
                 const int autoSizeHeader = -2;
                 this.keyListView.Columns.Add(Strings.EditEncryptedKeyFileDialog_ColumnChange, autoSizeHeader);
+                this.keyListView.Columns.Add(Strings.EditEncryptedKeyFileDialog_ColumnState, autoSizeHeader);
                 this.keyListView.Columns.Add(Strings.EditEncryptedKeyFileDialog_ColumnSubject, autoSizeHeader);
                 this.keyListView.Columns.Add(Strings.EditEncryptedKeyFileDialog_ColumnSerial, autoSizeHeader);
                 this.keyListView.Columns.Add(Strings.EditEncryptedKeyFileDialog_ColumnAlgorithm, autoSizeHeader);
@@ -220,7 +222,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                 this.layout.Controls.Add(this.keyListView, 0, 4);
                 this.layout.SetColumnSpan(this.keyListView, this.layout.ColumnCount);
 
-                // Add every possible change value for proper sizing
+                // Add every possible change/state value for proper sizing
                 // Dummy items will be deleted after size has been calculated (form load event)
                 this.keyListView.Items.Add(newKeyAction).Font = new Font(this.keyListView.Font, actionFont);
                 this.keyListView.Items.Add(delKeyAction).Font = new Font(this.keyListView.Font, actionFont);
@@ -319,30 +321,25 @@ namespace EpiSource.KeePass.Ekf.UI {
                 this.lblValidationError.Text = message;
             }
 
-            private void ClearKeyList() {
-                this.keyList.Clear();
-            }
-            
-            private bool AddKeyIfNew(KeyPairModel keyModel) {
-                var cert = keyModel.KeyPair.Certificate;
-                if (this.keyList.ContainsKey(cert.Thumbprint)) {
-                    return false;
-                }
-                
-                this.keyList.Add(cert.Thumbprint, keyModel);
-                return true;
-            }
-
             private void RefreshKeyListView() {
                 this.keyListView.BeginUpdate();
                 
+                var changedAuthorizations = this.keyListView.ItemTags<KeyPairModel>()
+                    .Where(kpm => kpm.CurrentAuthorization != kpm.NextAuthorization)
+                    .ToDictionary(kpm => kpm.KeyPair.Certificate.Thumbprint, kpm => kpm.NextAuthorization);
                 this.keyListView.Items.Clear();
 
-                this.keyList.Values
+                this.updatingKeyPairProvider.KeyPairProvider.GetAvailableKeyPairs()
                     .OrderBy(m => String.IsNullOrWhiteSpace(m.KeyPair.Certificate.Subject))
                     .ThenBy(m => m.KeyPair.Certificate.Subject)
                     .ThenBy(m => m.KeyPair.Certificate.SerialNumber)
                     .ForEach(m => {
+                        var thumbprint = m.KeyPair.Certificate.Thumbprint;
+                        KeyPairModel.Authorization authorization;
+                        if (changedAuthorizations.TryGetValue(thumbprint, out authorization)) {
+                            m.NextAuthorization = authorization;
+                        }
+                        
                         if (!this.chkAnyKeyUsage.Checked 
                                 && m.NextAuthorization != KeyPairModel.Authorization.Authorized
                                 && m.NextAuthorization == m.CurrentAuthorization
@@ -359,6 +356,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                         this.UpdateItemAction(item);
                         
                         var cert = m.KeyPair.Certificate;
+                        item.SubItems.Add(m.KeyPair.IsReadyForDecryptCms ? stateConnected : stateNotConnected);
                         item.SubItems.Add(cert.Subject);
                         item.SubItems.Add(cert.SerialNumber);
                         item.SubItems.Add(cert.PublicKey.Oid.FriendlyName);
@@ -372,6 +370,8 @@ namespace EpiSource.KeePass.Ekf.UI {
                 this.keyListView.EndUpdate();
                 this.keyListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
                 this.keyListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+                
+                this.ValidateInput();
             }
 
             private void UpdateItemAction(ListViewItem item) {
@@ -394,12 +394,16 @@ namespace EpiSource.KeePass.Ekf.UI {
                 base.OnShown(e);
 
                 GlobalWindowManager.AddWindow(this, this);
+                
+                this.updatingKeyPairProvider.StartUpdates();
             }
 
             protected override void OnClosed(EventArgs e) {
                 base.OnClosed(e);
 
                 GlobalWindowManager.RemoveWindow(this);
+                
+                this.updatingKeyPairProvider.Dispose();
             }
 
             bool IGwmWindow.CanCloseWithoutDataLoss { get { return false; } }

--- a/EpiSource.KeePass.Ekf/UI/EditEncryptedKeyFileDialog.controls.cs
+++ b/EpiSource.KeePass.Ekf/UI/EditEncryptedKeyFileDialog.controls.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
@@ -25,8 +24,6 @@ namespace EpiSource.KeePass.Ekf.UI {
             private static readonly string noChangeCaption = Strings.EditEncryptedKeyFileDialog_KeyActionNoChange;
             private static readonly string newKeyAction = Strings.EditEncryptedKeyFileDialog_KeyActionAuthorize;
             private static readonly string delKeyAction = Strings.EditEncryptedKeyFileDialog_KeyActionUnauthorize;
-            private static readonly string stateConnected = Strings.EditEncryptedKeyFileDialog_KeyStateConnected;
-            private static readonly string stateNotConnected = Strings.EditEncryptedKeyFileDialog_KeyStateNotConnected;
             
             private readonly TableLayoutPanel layout = new TableLayoutPanel();
             private readonly CustomListViewEx keyListView = new CustomListViewEx();
@@ -356,7 +353,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                         this.UpdateItemAction(item);
                         
                         var cert = m.KeyPair.Certificate;
-                        item.SubItems.Add(m.KeyPair.IsReadyForDecryptCms ? stateConnected : stateNotConnected);
+                        item.SubItems.Add(m.DescribePrivateKeyState());
                         item.SubItems.Add(cert.Subject);
                         item.SubItems.Add(cert.SerialNumber);
                         item.SubItems.Add(cert.PublicKey.Oid.FriendlyName);

--- a/EpiSource.KeePass.Ekf/UI/EditEncryptedKeyFileDialog.cs
+++ b/EpiSource.KeePass.Ekf/UI/EditEncryptedKeyFileDialog.cs
@@ -1,17 +1,15 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 using EpiSource.KeePass.Ekf.Crypto;
 using EpiSource.KeePass.Ekf.Keys;
-using EpiSource.KeePass.Ekf.Plugin;
 
 using Episource.KeePass.EKF.Resources;
 
+using EpiSource.KeePass.Ekf.UI.Util;
 using EpiSource.KeePass.Ekf.UI.Windows;
-using EpiSource.Unblocker.Util;
 
 using KeePass.App;
 using KeePass.Forms;
@@ -32,8 +30,10 @@ namespace EpiSource.KeePass.Ekf.UI {
             private readonly LiveKeyDataStore activeDbKey;
             private IKeyDataStore nextKey;
             private bool keyWasExported;
+            
+            private readonly KeyPairProviderDeviceEventUpdater updatingKeyPairProvider;
 
-            internal EditEncryptedKeyFileDialog(IOConnectionInfo dbPath, IUserKey activeDbKey, IKeyPairProvider authCandidates, bool permitNewKey) {
+            internal EditEncryptedKeyFileDialog(IOConnectionInfo dbPath, IUserKey activeDbKey, IKeyPairProvider authCandidates, bool permitNewKey, UIFactory uiFactory) {
                 this.dbPath = dbPath;
                 this.defaultKeyFileName = Path.GetFileName(dbPath.Path) + ".keyx";
                 this.activeDbKey = activeDbKey == null ? null : new LiveKeyDataStore(activeDbKey);
@@ -43,13 +43,8 @@ namespace EpiSource.KeePass.Ekf.UI {
 
                 this.InitializeUI();
                 
-                foreach (var keyPair in authCandidates.GetAvailableKeyPairs()) {
-                    if (!this.AddKeyIfNew(keyPair)) {
-                        throw new ArgumentException(
-                            @"Duplicated key pair: " + keyPair.KeyPair.Certificate.Thumbprint,
-                            "authCandidates");
-                    }
-                }
+                this.updatingKeyPairProvider = new KeyPairProviderDeviceEventUpdater(authCandidates, uiFactory);
+                this.updatingKeyPairProvider.Changed += (s, e) => this.RefreshKeyListView();
                 
                 // RefreshKeyList requires UI to be initialized!
                 this.RefreshKeyListView();
@@ -155,7 +150,7 @@ namespace EpiSource.KeePass.Ekf.UI {
 
                 var authorizationChanged =
                     this.DialogResult == DialogResult.OK ||
-                    this.keyList.Values
+                    this.keyListView.ItemTags<KeyPairModel>()
                         .Select(x => x.NextAuthorization != x.CurrentAuthorization)
                         .FirstOrDefault();
                 if (!authorizationChanged) {
@@ -163,14 +158,14 @@ namespace EpiSource.KeePass.Ekf.UI {
                 }
 
                 var selectedKeys =
-                    this.keyList.Values
+                    this.keyListView.ItemTags<KeyPairModel>()
                         .Where(x => x.NextAuthorization == KeyPairModel.Authorization.Authorized)
                         .Select(x => x.KeyPair);
                 return new KeyEncryptionRequest(this.dbPath, this.nextKey.KeyData, selectedKeys);
             }
 
             private bool ValidateInput() {
-                if (this.keyList.Count == 0) {
+                if (this.keyListView.ItemTags<KeyPairModel>().FirstOrDefault() == null) {
                     this.ShowValidationError(Strings.EditEncryptedKeyFileDialog_ValidationMessageNoSmartcard);
                     return false;
                 }
@@ -181,8 +176,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                     return false;
                 }
 
-                var anyKeySelected =
-                    this.keyList.Any(x => x.Value.NextAuthorization == KeyPairModel.Authorization.Authorized);
+                var anyKeySelected = this.keyListView.ItemTags<KeyPairModel>().Any(x => x.NextAuthorization == KeyPairModel.Authorization.Authorized);
                 if (!anyKeySelected) {
                     this.ShowValidationError(Strings.EditEncryptedKeyFileDialog_ValidationMessageSelectSmartcard);
                     return false;

--- a/EpiSource.KeePass.Ekf/UI/EditEncryptedKeyFileDialogFactory.cs
+++ b/EpiSource.KeePass.Ekf/UI/EditEncryptedKeyFileDialogFactory.cs
@@ -26,7 +26,7 @@ namespace EpiSource.KeePass.Ekf.UI {
             // Note: DefaultKeyPairProvider#FromDbPath constructor blocks if busy HW is involved - unblock
             var keyPairProvider = this.uiFactory.SmartcardOperationDialog.DoCryptoWithMessagePumpShort(ct => DefaultKeyPairProvider.FromSystemKeyStore());
 
-            var dialog = new EditEncryptedKeyFileDialog(dbPath, activeDbKey, keyPairProvider, true);
+            var dialog = new EditEncryptedKeyFileDialog(dbPath, activeDbKey, keyPairProvider, true, this.uiFactory);
             return dialog.ShowDialogAndGenerateEncryptionRequest();
         }
 
@@ -48,7 +48,7 @@ namespace EpiSource.KeePass.Ekf.UI {
             // Note: DefaultKeyPairProvider#FromDbPath constructor blocks if busy HW is involved - unblock
             var keyPairProvider = this.uiFactory.SmartcardOperationDialog.DoCryptoWithMessagePumpShort(ct => DefaultKeyPairProvider.FromEncryptedKeyFileBinary(encryptedKeyFileData));
 
-            var dialog = new EditEncryptedKeyFileDialog(dbPath, keyFile, keyPairProvider, false);
+            var dialog = new EditEncryptedKeyFileDialog(dbPath, keyFile, keyPairProvider, false, this.uiFactory);
             return dialog.ShowDialogAndGenerateEncryptionRequest();
         }
 

--- a/EpiSource.KeePass.Ekf/UI/SmartcardRequiredDialog.cs
+++ b/EpiSource.KeePass.Ekf/UI/SmartcardRequiredDialog.cs
@@ -7,6 +7,7 @@ using System.Windows.Forms;
 
 using Episource.KeePass.EKF.Resources;
 
+using EpiSource.KeePass.Ekf.UI.Util;
 using EpiSource.KeePass.Ekf.Util;
 using EpiSource.KeePass.Ekf.Util.Windows;
 using EpiSource.Unblocker.Hosting;
@@ -24,34 +25,29 @@ namespace EpiSource.KeePass.Ekf.UI {
             internal readonly CustomListViewEx keyListView = new CustomListViewEx();
             
             private bool loaded = false;
-            private bool refreshSmartcardOperationPending = false;
 
             private readonly TableLayoutPanel layout = new TableLayoutPanel();
             private Button btnOk;
-
-            private NativeDeviceEvents deviceEventListener;
-            private readonly Timer refreshDelayTimer = new Timer() {
-                Interval = 250
-            };
+            
             private readonly Timer redrawAfterScrollDelayTimer = new Timer() {
                 Interval = 150
             };
-
-            private readonly IKeyPairProvider keyPairProvider;
+            
             private readonly UIFactory uiFactory;
+            private readonly KeyPairProviderDeviceEventUpdater updatingKeyPairProvider;
 
             internal SmartcardRequiredDialog(Form owner, IKeyPairProvider keyPairProvider, UIFactory uiFactory) {
                 if (owner != null) {
                     this.Owner = owner;
                 }
 
-                this.keyPairProvider = keyPairProvider;
                 this.uiFactory = uiFactory;
+                
+                this.updatingKeyPairProvider = new KeyPairProviderDeviceEventUpdater(keyPairProvider, uiFactory);
+                this.updatingKeyPairProvider.Changed += (s, e) => this.ReplaceList();
 
                 this.InitializeUI();
                 this.ReplaceList();
-
-                this.refreshDelayTimer.Tick += this.OnRefreshRequested;
             }
 
             private void InitializeUI() {
@@ -206,7 +202,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                     // detect scrolling and redraw control after scrolling has finished (using delay)
                     if (args.ItemIndex == 0 && args.Bounds.Location != keyListViewScrollDetectionReferenceLocation) {
                         keyListViewScrollDetectionReferenceLocation = args.Bounds.Location;
-                        RestartFormsTimer(this.redrawAfterScrollDelayTimer);
+                        this.redrawAfterScrollDelayTimer.Restart();
                     }
                 };
                 this.keyListView.DrawColumnHeader += (sender, args) => args.DrawDefault = true;
@@ -309,27 +305,10 @@ namespace EpiSource.KeePass.Ekf.UI {
                 var prevCheckedItems = new HashSet<string>();
                 try {
                     if (this.loaded) {
-                        // note: result == false does not imply IsReadyForDecryptCms to be unchanged!
-                        // => replace list independent of result
-                        // NOTE: Refresh blocks if busy HW is involved -> unblocker
-                        IFunctionInvocationResult<IKeyPairProvider, bool> refreshResult;
-                        try {
-                            this.refreshSmartcardOperationPending = true;
-                            refreshResult = this.uiFactory.SmartcardOperationDialog.DoCryptoWithMessagePumpShort(
-                                this.keyPairProvider, (ct, _) => _.Refresh());
-                        } catch (TaskCanceledException) {
-                            // that's fine - skip this refresh
-                            return;
-                        } finally {
-                            this.refreshSmartcardOperationPending = false;
-                        }
-
                         // closing dialog was requested while waiting for Refresh - skip update
                         if (this.DialogResult != DialogResult.None) {
                             return;
                         }
-
-                        this.keyPairProvider.Refresh(refreshResult.PostInvocationTarget);
 
                         prevCheckedItems = this.keyListView.CheckedItems.Cast<ListViewItem>()
                                                .Select(i => i.Tag as KeyPairModel)
@@ -343,7 +322,7 @@ namespace EpiSource.KeePass.Ekf.UI {
 
                     ListViewItem firstAvailItem = null;
                     var availItemCount = 0;
-                    foreach (var kpm in this.keyPairProvider.GetAuthorizedKeyPairs()
+                    foreach (var kpm in this.updatingKeyPairProvider.KeyPairProvider.GetAuthorizedKeyPairs()
                                             .DistinctBy(kp => kp.KeyPair.Certificate.Thumbprint)) {
 
                         var cert = kpm.KeyPair.Certificate;
@@ -389,16 +368,6 @@ namespace EpiSource.KeePass.Ekf.UI {
                 this.keyListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
             }
 
-            private void OnRefreshRequested(object sender, EventArgs args) {
-                this.refreshDelayTimer.Stop();
-
-                if (this.refreshSmartcardOperationPending) {
-                    RestartFormsTimer(this.refreshDelayTimer);
-                } else {
-                    this.ReplaceList();
-                }
-            }
-
             protected override void OnLoad(EventArgs e) {
                 base.OnLoad(e);
 
@@ -416,23 +385,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                     this.Owner.Enabled = false;
                 }
 
-                if (this.deviceEventListener == null) {
-                    this.deviceEventListener = new NativeDeviceEvents();
-
-                    this.deviceEventListener.AnyDeviceEvent += (sender, args) => {
-                        if (args.Reason == NativeDeviceEvents.NotificationReason.Unknown) {
-                            // ignore unrelated events
-                            return;
-                        }
-
-                        if (this.InvokeRequired) {
-                            this.Invoke((MethodInvoker) (() => RestartFormsTimer(this.refreshDelayTimer)));
-                        } else {
-                            RestartFormsTimer(this.refreshDelayTimer);
-                        }
-
-                    };
-                }
+                this.updatingKeyPairProvider.StartUpdates();
             }
 
             protected override void OnClosed(EventArgs e) {
@@ -443,21 +396,8 @@ namespace EpiSource.KeePass.Ekf.UI {
                 if (this.Owner != null) {
                     this.Owner.Enabled = true;
                 }
-
-                if (this.deviceEventListener != null) {
-                    this.deviceEventListener.Dispose();
-                    this.deviceEventListener = null;
-                }
-            }
-
-            private static void RestartFormsTimer(Timer t) {
-                t.Stop();
-
-                // restart timer: force change of interval; else interval continues!
-                var modulo = t.Interval % 5;
-                t.Interval += modulo == 0 ? 1 : -1 * modulo;
-
-                t.Start();
+                
+                this.updatingKeyPairProvider.Dispose();
             }
 
             bool IGwmWindow.CanCloseWithoutDataLoss {

--- a/EpiSource.KeePass.Ekf/UI/SmartcardRequiredDialog.cs
+++ b/EpiSource.KeePass.Ekf/UI/SmartcardRequiredDialog.cs
@@ -33,7 +33,6 @@ namespace EpiSource.KeePass.Ekf.UI {
                 Interval = 150
             };
             
-            private readonly UIFactory uiFactory;
             private readonly KeyPairProviderDeviceEventUpdater updatingKeyPairProvider;
 
             internal SmartcardRequiredDialog(Form owner, IKeyPairProvider keyPairProvider, UIFactory uiFactory) {
@@ -41,8 +40,6 @@ namespace EpiSource.KeePass.Ekf.UI {
                     this.Owner = owner;
                 }
 
-                this.uiFactory = uiFactory;
-                
                 this.updatingKeyPairProvider = new KeyPairProviderDeviceEventUpdater(keyPairProvider, uiFactory);
                 this.updatingKeyPairProvider.Changed += (s, e) => this.ReplaceList();
 

--- a/EpiSource.KeePass.Ekf/UI/SmartcardRequiredDialog.cs
+++ b/EpiSource.KeePass.Ekf/UI/SmartcardRequiredDialog.cs
@@ -19,9 +19,6 @@ using Timer = System.Windows.Forms.Timer;
 namespace EpiSource.KeePass.Ekf.UI {
     public partial class SmartcardRequiredDialogFactory {
         private sealed class SmartcardRequiredDialog : Form, IGwmWindow {
-            private static readonly string stateConnected = Strings.SmartcardRequiredDialog_KeyStateConnected;
-            private static readonly string stateNotConnected = Strings.SmartcardRequiredDialog_KeyStateNotConnected;
-
             internal readonly CustomListViewEx keyListView = new CustomListViewEx();
             
             private bool loaded = false;
@@ -223,8 +220,9 @@ namespace EpiSource.KeePass.Ekf.UI {
 
                 // Add every possible state value for proper sizing
                 // Dummy items will be deleted after size has been calculated (form load event)
-                this.keyListView.Items.Add(stateConnected);
-                this.keyListView.Items.Add(stateNotConnected);
+                this.keyListView.Items.Add(Strings.KeyPairExtension_KeyStateConnected);
+                this.keyListView.Items.Add(Strings.KeyPairExtension_KeyStateMismatch);
+                this.keyListView.Items.Add(Strings.KeyPairExtension_KeyStateNotConnected);
 
                 // prevent changing column width
                 this.keyListView.ColumnWidthChanging += (sender, args) => {
@@ -323,10 +321,7 @@ namespace EpiSource.KeePass.Ekf.UI {
                                             .DistinctBy(kp => kp.KeyPair.Certificate.Thumbprint)) {
 
                         var cert = kpm.KeyPair.Certificate;
-                        var stateText = stateNotConnected;
-                        if (kpm.KeyPair.IsReadyForDecryptCms) {
-                            stateText = stateConnected;
-                        }
+                        var stateText = kpm.DescribePrivateKeyState();
 
                         var item = new ListViewItem(stateText);
                         item.UseItemStyleForSubItems = false;

--- a/EpiSource.KeePass.Ekf/UI/Util/KeyPairExtensions.cs
+++ b/EpiSource.KeePass.Ekf/UI/Util/KeyPairExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+
+using EpiSource.KeePass.Ekf.Crypto;
+
+using Episource.KeePass.EKF.Resources;
+
+namespace EpiSource.KeePass.Ekf.UI.Util {
+    public static class KeyPairExtensions {
+        public static String DescribePrivateKeyState(this KeyPairModel kpm) {
+            return kpm.KeyPair.DescribePrivateKeyState();
+        }
+
+        public static String DescribePrivateKeyState(this IKeyPair kp) {
+            if (kp.IsMismatch == true) {
+                return Strings.KeyPairExtension_KeyStateMismatch;
+            }
+            if (kp.IsAccessible) {
+                return Strings.KeyPairExtension_KeyStateConnected;
+            }
+            return Strings.KeyPairExtension_KeyStateNotConnected;
+        }
+    }
+}

--- a/EpiSource.KeePass.Ekf/UI/Util/KeyPairProviderDeviceEventUpdater.cs
+++ b/EpiSource.KeePass.Ekf/UI/Util/KeyPairProviderDeviceEventUpdater.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+using EpiSource.KeePass.Ekf.Util.Windows;
+using EpiSource.Unblocker.Hosting;
+
+namespace EpiSource.KeePass.Ekf.UI.Util {
+    
+    public class KeyPairProviderDeviceEventUpdater : IDisposable {
+        
+        private readonly IKeyPairProvider keyPairProvider;
+        private readonly UIFactory uiFactory;
+        
+        private Timer refreshDelayTimer;
+        private NativeDeviceEvents deviceEventListener;
+        private bool refreshSmartcardOperationPending = false;
+
+        public KeyPairProviderDeviceEventUpdater(IKeyPairProvider keyPairProvider, UIFactory uiFactory, int delayMs = 250) {
+            this.keyPairProvider = keyPairProvider;
+            this.uiFactory = uiFactory;
+            
+            this.refreshDelayTimer = new Timer() {
+                Interval = delayMs
+            };
+            this.refreshDelayTimer.Tick += this.OnTick;
+        }
+        
+        // invoked on UI thread
+        public event EventHandler<EventArgs> Changed;
+
+        public IKeyPairProvider KeyPairProvider {
+            get { return this.keyPairProvider; }
+        }
+
+        public void StartUpdates() {
+            if (this.refreshDelayTimer == null) {
+                throw new ObjectDisposedException("KeyPairProviderDeviceEventUpdater instance has been disposed");
+            }
+            
+            if (this.deviceEventListener == null) {
+                this.deviceEventListener = new NativeDeviceEvents();
+
+                this.deviceEventListener.AnyDeviceEvent += (sender, args) => {
+                    if (args.Reason == NativeDeviceEvents.NotificationReason.Unknown) {
+                        // ignore unrelated events
+                        return;
+                    }
+
+                    // Timer internally marshalls to the UI thread - no Control#Invoke required
+                    this.refreshDelayTimer.Restart();
+                };
+            }
+        }
+        
+        public void Dispose() {
+            if (this.deviceEventListener != null) {
+                this.deviceEventListener.Dispose();
+                this.deviceEventListener = null;
+            }
+            if (this.refreshDelayTimer != null) {
+                this.refreshDelayTimer.Stop();
+                this.refreshDelayTimer.Tick -= OnTick;
+                this.refreshDelayTimer.Dispose();
+                this.refreshDelayTimer = null;
+            }
+        }
+
+        private void OnTick(object sender, EventArgs e) {
+            this.refreshDelayTimer.Stop();
+
+            if (this.refreshSmartcardOperationPending) {
+                this.refreshDelayTimer.Restart();
+                return;
+            } 
+            
+            IFunctionInvocationResult<IKeyPairProvider, bool> refreshResult;
+            try {
+                this.refreshSmartcardOperationPending = true;
+                refreshResult = this.uiFactory.SmartcardOperationDialog.DoCryptoWithMessagePumpShort(
+                    this.keyPairProvider, (ct, _) => _.Refresh());
+            } catch (TaskCanceledException) {
+                // that's fine - skip this refresh
+                return;
+            } finally {
+                this.refreshSmartcardOperationPending = false;
+            }
+
+            var hasChanged = this.keyPairProvider.Refresh(refreshResult.PostInvocationTarget);
+            if (hasChanged && this.Changed != null) {
+                // Timer events run on UI thread, therefore Changed event, too
+                this.Changed(this, EventArgs.Empty);
+            }
+        }
+    }
+    
+}

--- a/EpiSource.KeePass.Ekf/UI/Util/ListViewExtensions.cs
+++ b/EpiSource.KeePass.Ekf/UI/Util/ListViewExtensions.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace EpiSource.KeePass.Ekf.UI.Util {
+    public static class ListViewExtensions {
+        public static IEnumerable<T> ItemTags<T>(this ListView listView) {
+            return listView.Items
+                    .Cast<ListViewItem>()
+                    .Where(item => item.Tag != null)
+                    .Select(item => item.Tag)
+                    .Cast<T>();
+        }
+    }
+}

--- a/EpiSource.KeePass.Ekf/UI/Util/TimerExtensions.cs
+++ b/EpiSource.KeePass.Ekf/UI/Util/TimerExtensions.cs
@@ -1,0 +1,19 @@
+using System.Windows.Forms;
+
+namespace EpiSource.KeePass.Ekf.UI.Util {
+    
+    public static class TimerExtensions {
+        
+        public static void Restart(this Timer t) {
+            t.Stop();
+
+            // restart timer: force change of interval; else interval continues!
+            var modulo = t.Interval % 5;
+            t.Interval += modulo == 0 ? 1 : -1 * modulo;
+
+            t.Start();
+        }
+        
+    }
+    
+}


### PR DESCRIPTION
The following changes are introduced:
 - The "Edit Encrypted Key File" Dialog also shows private key connections state (optionally use this  as early indicator, whether there might be a incompatibility)
 - add private key state "mismatch" (in addition to "connected", "not connected") - "mismatch" is shown if querying the private key fails with either `NTE_BAD_PUBLIC_KEY` or `NTE_BAD_KEY`. Both are likely related to corruption/misconfiguration of the system's certificate store.
 - allow healing when querying private key properties (disable [CRYPT_ACQUIRE_NO_HEALING](https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptacquirecertificateprivatekey#parameters) option) - healing will sometimes solve `NTE_BAD_PUBLIC_KEY` issues*
 - also pulls in the changes of #14 

*) On my systems I needed to fiddle with the [CERT_KEY_PROV_INFO_PROP_ID](https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certsetcertificatecontextproperty#cert_key_prov_info_prop_id) provider property associated with a cert to force `NTE_BAD_PUBLIC_KEY`: I've overwritten this with the value of another certificate (for another key slot, but sharing the same algorithm parameters). Enabling healing worked around this forced `NTE_BAD_PUBLIC_KEY`. I'm not aware of negative side effects that might come along with the healing, other that it might change persistent provider data. 

I could imagine, that `NTE_BAD_PUBLIC_KEY` might also occur, when the key on the smartcard is recreated / overwritten without updating the computer's or key file's cached certificate. Was not able to easily reproduce this though (e.g. overwriting a yubikey PIV slot led to "not connected" / `NTE_BAD_KEYSET` during my testing).